### PR TITLE
Add support for AMP interactive comparison

### DIFF
--- a/main.css
+++ b/main.css
@@ -18,6 +18,14 @@ button {
   margin-top: 10px;
 }
 
+.select-box {
+  display: flex;
+}
+
+.select-box input {
+  width: auto;
+}
+
 input,
 select {
   width: 200px;

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 )
 
 type TplData struct {
@@ -97,6 +98,10 @@ func main() {
 		<form>
 			<label for="url">Custom URL:</label>
 			<input type="url" id="url" name="target" value="{{.FrontendURL}}">
+			<div class="select-box">
+				<input type="checkbox" id="amp" name="amp" value="amp">
+				<label for="amp">Show AMP variant (DCR Only)</label>
+			</div>
 			<button>Update</button>
 		</form>
 
@@ -115,7 +120,10 @@ func main() {
 					{{end}}
 				</optgroup>
 			</select>
-		
+			<div class="select-box">
+				<input type="checkbox" id="amp-2" name="amp" value="amp">
+				<label for="amp-2">Show AMP variant (DCR Only)</label>
+			</div>
 			<button>Update</button>
 		</form>
 
@@ -149,15 +157,25 @@ func main() {
 			target = customTarget
 		}
 
+		isAmp := r.URL.Query().Get(("amp")) == "amp"
+
 		targetURL, _ := url.Parse(target)
 		path := targetURL.Path
 
 		frontendTarget := fmt.Sprintf("https://www.theguardian.com%s", path)
 		DCRTarget := ""
+
 		if *isLocalDCR {
-			DCRTarget = fmt.Sprintf("http://localhost:3030/Interactive?url=https://www.theguardian.com%s", path)
+			if isAmp {
+				DCRTarget = fmt.Sprintf("http://localhost:3030/AMPInteractive?url=https://www.theguardian.com%s", path)
+			} else {
+				DCRTarget = fmt.Sprintf("http://localhost:3030/Interactive?url=https://www.theguardian.com%s", path)
+			}
 		} else {
 			DCRTarget = frontendTarget + "?dcr"
+			if isAmp {
+				DCRTarget = strings.Replace(DCRTarget, "www.theguardian.com", "amp.theguardian.com", 1)
+			}
 		}
 
 		data := TplData{


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adds support for loading AMP interactives on both local and prod envs.

When AMP is selected, it will load the AMP page for the DCR version. The frontend version will remain on the regular version, since an AMP version does not exist. We should expect at least some differences for this reason, but it should provide the ability to check that all the elements exist and render correctly.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

1. Run the app
2. Tick the AMP variant option
3. Pick your article and press update
